### PR TITLE
upgrade flameshot to 0.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Flameshot install
-      run: make flameshot
+      run: make flameshot-install
     - name: Docker install
       run: make docker
     - name: Docker-compose install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Flameshot install
+      run: make flameshot
     - name: Docker install
       run: make docker
     - name: Docker-compose install
       run: make docker-compose
-    - name: Flameshot install
-      run: make flameshot
     - name: Python 3.6 install
       run: make python-three-six-install
     - name: Python 3.6 supporting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
       run: make docker
     - name: Docker-compose install
       run: make docker-compose
+    - name: Flameshot install
+      run: make flameshot
     - name: Python 3.6 install
       run: make python-three-six-install
     - name: Python 3.6 supporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added TickTick Native App using [nativefier](https://github.com/jiahaog/nativefier)
 - Added [Yet Another Dotfile Manager](https://yadm.io)
+- Flameshot: download and install 0.6.0 deb from Github (apt installs 0.5.1-2 at time of writing)
 
 ## [0.3.0]
 

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,11 @@ docker-compose:
 	# Test the installation
 	docker-compose --version
 
-flameshot: ## Install flameshot, update gnome keybindings
-flameshot: update
+flameshot-install: ## Install Flameshot
+flameshot-install: update
 
 	# Ubuntu >=18.04
-	# sudo apt install -y flameshot (apt fetches a 0.5.x version)
+	# sudo apt install -y flameshot (apt fetches a 0.5.x version, want >= 0.6.0)
 
 	## Snap cannot be found
 	# sudo snap install flameshot-app
@@ -141,13 +141,12 @@ flameshot: update
 	mkdir /tmp/flameshot/
 	wget 'https://github.com/lupoDharkael/flameshot/releases/download/v0.6.0/flameshot_0.6.0_bionic_x86_64.deb' -P /tmp/flameshot
 
-	## Install dependencies (https://askubuntu.com/a/40050)
-	# mark dependencies, install required dependencies
+	## Install dependencies (https://askubuntu.com/a/248675/1042945)
+	# Install package, and install required dependencies
 	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb || sudo apt-get -y --fix-broken install
-	# install required dependencies
-	# sudo apt-get -f install
-	# successfully install package
-	# sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
+
+flameshot: ## Install Flameshot and Update gnome keybindings
+flameshot: flameshot-install
 
 	# Update gnome keybindings
 	# source: https://askubuntu.com/a/1116076

--- a/Makefile
+++ b/Makefile
@@ -132,12 +132,21 @@ flameshot: update
 	# Ubuntu >=18.04
 	# sudo apt install -y flameshot (apt fetches a 0.5.x version)
 
-	# Below is 0.6.0 version directly from github
+	## Snap cannot be found
+	# sudo snap install flameshot-app
 
+	## Download deb (0.6.0) from GitHub
 	sudo apt remove -y flameshot
 	rm -rf /tmp/flameshot/
 	mkdir /tmp/flameshot/
 	wget 'https://github.com/lupoDharkael/flameshot/releases/download/v0.6.0/flameshot_0.6.0_bionic_x86_64.deb' -P /tmp/flameshot
+
+	## Install dependencies (https://askubuntu.com/a/40050)
+	# mark dependencies
+	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
+	# install required dependencies
+	sudo apt-get -f install
+	# successfully install package
 	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
 
 	# Update gnome keybindings
@@ -149,8 +158,6 @@ flameshot: update
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/ command '/usr/bin/flameshot gui'
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/ binding 'Print'
 
-	## doesn't seem to work
-	# sudo snap install flameshot-app
 
 flatpak: ## Install flatpack on GNOME
 flatpak: update

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,15 @@ flameshot: ## Install flameshot, update gnome keybindings
 flameshot: update
 
 	# Ubuntu >=18.04
-	sudo apt install -y flameshot
+	# sudo apt install -y flameshot (apt fetches a 0.5.x version)
+
+	# Below is 0.6.0 version directly from github
+
+	sudo apt remove -y flameshot
+	rm -rf /tmp/flameshot/
+	mkdir /tmp/flameshot/
+	wget 'https://github.com/lupoDharkael/flameshot/releases/download/v0.6.0/flameshot_0.6.0_bionic_x86_64.deb' -P /tmp/flameshot
+	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
 
 	# Update gnome keybindings
 	# source: https://askubuntu.com/a/1116076

--- a/Makefile
+++ b/Makefile
@@ -142,12 +142,12 @@ flameshot: update
 	wget 'https://github.com/lupoDharkael/flameshot/releases/download/v0.6.0/flameshot_0.6.0_bionic_x86_64.deb' -P /tmp/flameshot
 
 	## Install dependencies (https://askubuntu.com/a/40050)
-	# mark dependencies
-	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
+	# mark dependencies, install required dependencies
+	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb || sudo apt-get -y --fix-broken install
 	# install required dependencies
-	sudo apt-get -f install
+	# sudo apt-get -f install
 	# successfully install package
-	sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
+	# sudo dpkg --skip-same-version -i /tmp/flameshot/flameshot_0.6.0_bionic_x86_64.deb
 
 	# Update gnome keybindings
 	# source: https://askubuntu.com/a/1116076

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Personal Makefile to install common packages on Ubuntu based distributions
 
-- Install `ansible`, `cherrytree`, `Visual Studio Code`, `Chromium`, `docker`, `docker-compose`, `Flatpak`, `Nordvpn`, `nodejs`, `Peek`, `postman`, `python3.7`, `Signal Desktop`, `Slack`, `Snap`, `Spotify`, `Standard Notes`, `Steam`, `Sublime Text`, `Telegram`, `TickTick`, `Tresorit`, `yarn`,  and `zsh`
+- Install `ansible`, `cherrytree`, `Visual Studio Code`, `Chromium`, `docker`, `docker-compose`, `flameshot`, `Flatpak`, `Nordvpn`, `nodejs`, `Peek`, `postman`, `python3.7`, `Signal Desktop`, `Slack`, `Snap`, `Spotify`, `Standard Notes`, `Steam`, `Sublime Text`, `Telegram`, `TickTick`, `Tresorit`, `yarn`,  and `zsh`
 - Configure GNOME keybindings and personal preferences
 - Install GNOME themes from [tliron/install-gnome-themes](https://github.com/tliron/install-gnome-themes)
 


### PR DESCRIPTION
Upgrading Flameshot to 0.6.0 per <https://github.com/lupoDharkael/flameshot/releases/download/v0.6.0/flameshot_0.6.0_bionic_x86_64.deb>